### PR TITLE
add topic-ACL-based access controller

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -193,6 +193,12 @@
             <artifactId>lombok</artifactId>
             <scope>compile</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/io.strimzi/api -->
+        <dependency>
+            <groupId>io.strimzi</groupId>
+            <artifactId>api</artifactId>
+            <version>0.41.0</version>
+        </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>

--- a/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
@@ -33,11 +33,17 @@ public class AuthConfig {
     @Dynamic(label = "Basic Auth with Strimzi User", description = "When selected, users are permitted to authenticate using HTTP basic authentication using usernames and passwords of Strimzi's KafkaUser resources.", requires = {
         "quarkus.http.auth.basic=true",
         "apicurio.auth.enabled=true",
-        "apicurio.auth.owner-only-authorization=false"
     })
     @ConfigProperty(name = "apicurio.auth.basic-auth-with-strimzi-user.enabled", defaultValue = "false")
     @Info(category = "auth", description = "Enable basic auth with Strimzi user")
     Supplier<Boolean> basicAuthWithStrimziUserEnabled;
+
+    @Dynamic(label = "Topic ACL-Based Authorizer for Strimzi Users", description = "When enabled, users are permitted to read/write subjects if the corresponding KafkaUser has the relevant read/write ACLs to the corresponding topic", requires = {
+        "apicurio.auth.basic-auth-with-strimzi-user.enabled=true",
+    })
+    @ConfigProperty(name = "apicurio.auth.topic-acl-based-authorizer.enabled", defaultValue = "false")
+    @Info(category = "auth", description = "Topic ACL Based Authorizer for Strimzi Users")
+    Supplier<Boolean> topicBasedAclAuthorizerEnabled;
 
     @ConfigProperty(name = "apicurio.auth.strimzi.kubernetes.namespace", defaultValue = "kafka")
     @Info(category = "auth", description = "Kubernetes namespace to be queried for KafkaUser resources.")

--- a/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthConfig.java
@@ -33,7 +33,7 @@ public class AuthConfig {
     @Dynamic(label = "Basic Auth with Strimzi User", description = "When selected, users are permitted to authenticate using HTTP basic authentication using usernames and passwords of Strimzi's KafkaUser resources.", requires = {
         "quarkus.http.auth.basic=true",
         "apicurio.auth.enabled=true",
-        "apicurio.auth.owner-only-authorization=true"
+        "apicurio.auth.owner-only-authorization=false"
     })
     @ConfigProperty(name = "apicurio.auth.basic-auth-with-strimzi-user.enabled", defaultValue = "false")
     @Info(category = "auth", description = "Enable basic auth with Strimzi user")

--- a/app/src/main/java/io/apicurio/registry/auth/AuthorizedInterceptor.java
+++ b/app/src/main/java/io/apicurio/registry/auth/AuthorizedInterceptor.java
@@ -131,7 +131,7 @@ public class AuthorizedInterceptor {
         }
 
         // If basic auth with Strimzi users is enabled, and the user is authorized to read/write the relevant topic, allow it
-        if (authConfig.basicAuthWithStrimziUserEnabled.get() && !tabac.isAuthorized(context)) {
+        if (authConfig.topicBasedAclAuthorizerEnabled.get() && authConfig.basicAuthWithStrimziUserEnabled.get() && !tabac.isAuthorized(context)) {
             log.warn("Strimzi Topic ACL Based Access Control enabled and operation not permitted due to missing ACLs.");
             throw new ForbiddenException("User " + securityIdentity.getPrincipal().getName() + " is not authorized to perform the requested operation.");
         }

--- a/app/src/main/java/io/apicurio/registry/auth/TopicAclBasedAccessController.java
+++ b/app/src/main/java/io/apicurio/registry/auth/TopicAclBasedAccessController.java
@@ -1,0 +1,115 @@
+package io.apicurio.registry.auth;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.model.user.KafkaUser;
+import io.strimzi.api.kafka.model.user.KafkaUserAuthorizationSimple;
+import io.strimzi.api.kafka.model.user.KafkaUserSpec;
+import io.strimzi.api.kafka.model.user.acl.*;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.interceptor.InvocationContext;
+import org.slf4j.Logger;
+
+import java.util.List;
+import java.util.Optional;
+
+@ApplicationScoped
+public class TopicAclBasedAccessController extends AbstractAccessController {
+    @Inject
+    AuthConfig authConfig;
+
+    @Inject
+    KubernetesClient client;
+
+    @Inject
+    Logger log;
+
+    public TopicAclBasedAccessController() {
+    }
+
+    /**
+     * @see io.apicurio.registry.auth.IAccessController#isAuthorized(jakarta.interceptor.InvocationContext)
+     */
+    @Override
+    public boolean isAuthorized(InvocationContext context) {
+        Authorized annotation = context.getMethod().getAnnotation(Authorized.class);
+        AuthorizedLevel level = annotation.level();
+
+        // We follow the same permission model as that of Confluent's Topic ACL Authorizer
+        // https://docs.confluent.io/platform/current/confluent-security-plugins/schema-registry/authorization/topicacl_authorizer.html
+        var topicName = getTopicName(context);
+        if (topicName == null) {
+            return false;
+        }
+
+        return switch (level) {
+            case Read -> canReadTopic(topicName);
+            case Write -> canWriteTopic(topicName);
+            default -> false;
+        };
+    }
+
+    private String getTopicName(InvocationContext context) {
+        // Extract the topic name from the method arguments
+        Authorized annotation = context.getMethod().getAnnotation(Authorized.class);
+        AuthorizedStyle style = annotation.style();
+
+        String subjectName = null;
+        if (style == AuthorizedStyle.GroupAndArtifact) {
+            subjectName = getStringParam(context, 1);
+        } else if (style == AuthorizedStyle.ArtifactOnly) {
+            subjectName = getStringParam(context, 0);
+        }
+        // Assume that TopicNameStrategy is used (https://developer.confluent.io/courses/schema-registry/schema-subjects/#topicnamestrategy)
+        // (Confluent's Schema Registry Topic ACL Authorizer makes the same assumption)
+        return Optional.ofNullable(subjectName)
+            .map(name -> name.replaceAll("(-key|-value)$", ""))
+            .filter(name -> !name.isBlank())
+            .orElse(null);
+    }
+
+    private boolean canReadTopic(String topicName) {
+        return canAccessTopic(topicName, AclOperation.READ);
+    }
+
+    private boolean canWriteTopic(String topicName) {
+        return canAccessTopic(topicName, AclOperation.WRITE);
+    }
+
+    private boolean canAccessTopic(String topicName, AclOperation operation) {
+        // Check if the Strimzi user whose name is the same as the principal name has <operation> permission on the topic
+        KafkaUser user = Crds.kafkaUserOperation(client)
+            .inNamespace(authConfig.strimziKubernetesNamespace)
+            .list()
+            .getItems()
+            .stream()
+            .filter(u -> u.getMetadata().getName().equals(securityIdentity.getPrincipal().getName()))
+            .findFirst()
+            .orElse(null);
+        // simple authorization type means that ACLs are managed by the Kafka Admin API
+        KafkaUserAuthorizationSimple authorization = (KafkaUserAuthorizationSimple) Optional.ofNullable(user)
+            .map(KafkaUser::getSpec)
+            .map(KafkaUserSpec::getAuthorization)
+            .orElse(null);
+        if (authorization == null || !"simple".equals(authorization.getType())) {
+            return false;
+        }
+        // if there is an ALLOW rule for the operation and no DENY rule, then the operation is allowed
+        // if there is a DENY rule for the operation, then the operation is denied even if there is an ALLOW rule
+        return aclRuleExistsForTopic(topicName, AclRuleType.ALLOW, operation, authorization.getAcls())
+            && !aclRuleExistsForTopic(topicName, AclRuleType.DENY, operation, authorization.getAcls());
+    }
+
+    private boolean aclRuleExistsForTopic(String topicName, AclRuleType ruleType, AclOperation operation, List<AclRule> acls) {
+        return acls.stream()
+            .filter(acl -> acl.getResource().getType().equals("topic"))
+            .filter(acl -> acl.getOperations().contains(operation) || acl.getOperations().contains(AclOperation.ALL))
+            .filter(acl -> acl.getType() == ruleType)
+            .anyMatch(acl -> {
+                var resource = (AclRuleTopicResource) acl.getResource();
+                var prefixMatch = resource.getPatternType() == AclResourcePatternType.PREFIX;
+                return prefixMatch ? topicName.startsWith(resource.getName()) : topicName.equals(resource.getName());
+            });
+    }
+}

--- a/app/src/main/java/io/apicurio/registry/auth/TopicAclBasedAccessController.java
+++ b/app/src/main/java/io/apicurio/registry/auth/TopicAclBasedAccessController.java
@@ -91,8 +91,9 @@ public class TopicAclBasedAccessController extends AbstractAccessController {
         KafkaUserAuthorizationSimple authorization = (KafkaUserAuthorizationSimple) Optional.ofNullable(user)
             .map(KafkaUser::getSpec)
             .map(KafkaUserSpec::getAuthorization)
+            .filter(auth -> "simple".equals(auth.getType()))
             .orElse(null);
-        if (authorization == null || !"simple".equals(authorization.getType())) {
+        if (authorization == null) {
             return false;
         }
         // if there is an ALLOW rule for the operation and no DENY rule, then the operation is allowed

--- a/app/src/main/java/io/apicurio/registry/auth/TopicAclBasedAccessController.java
+++ b/app/src/main/java/io/apicurio/registry/auth/TopicAclBasedAccessController.java
@@ -35,12 +35,15 @@ public class TopicAclBasedAccessController extends AbstractAccessController {
     public boolean isAuthorized(InvocationContext context) {
         Authorized annotation = context.getMethod().getAnnotation(Authorized.class);
         AuthorizedLevel level = annotation.level();
+        AuthorizedStyle style = annotation.style();
 
         // We follow the same permission model as that of Confluent's Topic ACL Authorizer
         // https://docs.confluent.io/platform/current/confluent-security-plugins/schema-registry/authorization/topicacl_authorizer.html
         var topicName = getTopicName(context);
         if (topicName == null) {
-            return false;
+            // If the topic name cannot be extracted (because the operation is not related to a topic), then behave
+            // as if the operation is authorized.
+            return true;
         }
 
         return switch (level) {

--- a/app/src/test/java/io/apicurio/registry/auth/TopicAclBasedAccessControllerTest.java
+++ b/app/src/test/java/io/apicurio/registry/auth/TopicAclBasedAccessControllerTest.java
@@ -1,0 +1,169 @@
+package io.apicurio.registry.auth;
+
+import io.apicurio.registry.AbstractResourceTestBase;
+import io.apicurio.registry.ccompat.rest.ContentTypes;
+import io.apicurio.registry.utils.tests.ApicurioTestTags;
+import io.apicurio.registry.utils.tests.BasicAuthWithStrimziUsersTestProfile;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
+import io.strimzi.api.kafka.Crds;
+import io.strimzi.api.kafka.model.user.KafkaUserAuthorizationSimpleBuilder;
+import io.strimzi.api.kafka.model.user.KafkaUserBuilder;
+import io.strimzi.api.kafka.model.user.KafkaUserScramSha512ClientAuthenticationBuilder;
+import io.strimzi.api.kafka.model.user.acl.*;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+@WithKubernetesTestServer
+@TestProfile(BasicAuthWithStrimziUsersTestProfile.class)
+@Tag(ApicurioTestTags.SLOW)
+class TopicAclBasedAccessControllerTest extends AbstractResourceTestBase {
+    @Inject
+    KubernetesClient client;
+
+    @Inject
+    AuthConfig authConfig;
+
+    private static final String SCHEMA_BODY = """
+        {
+          "schema": "{\\"type\\":\\"record\\",\\"name\\":\\"test\\",\\"fields\\":[{\\"type\\":\\"string\\",\\"name\\":\\"field1\\"},{\\"type\\": \\"string\\",\\"name\\": \\"int3\\"}]}",
+          "schemaType": "AVRO",
+          "references": [
+          ]
+        }
+        """;
+
+    @Override
+    protected void deleteGlobalRules(int expectedDefaultRulesCount) throws Exception {
+        // Do nothing
+    }
+
+    private static final String USERNAME = "alice";
+    private static final String PASSWORD = "hunter2";
+
+    @BeforeEach
+    public void setupKubernetesResources() {
+        NamespaceBuilder namespaceBuilder = new NamespaceBuilder().withNewMetadata().withName(authConfig.strimziKubernetesNamespace).endMetadata();
+        client.namespaces().resource(namespaceBuilder.build()).createOr(NonDeletingOperation::update);
+        // Create secret for user alice
+        SecretBuilder secretBuilder = new SecretBuilder()
+            .withNewMetadata()
+            .withName(USERNAME)
+            .withNamespace(authConfig.strimziKubernetesNamespace)
+            .withLabels(Map.of("strimzi.io/kind", "KafkaUser"))
+            .endMetadata()
+            .addToData("password", Base64.getEncoder().encodeToString(PASSWORD.getBytes(StandardCharsets.UTF_8)));
+        client.secrets().inNamespace(authConfig.strimziKubernetesNamespace).resource(secretBuilder.build()).createOr(NonDeletingOperation::update);
+        // Create KafkaUser for user alice and allow them to read/write to "topic1", "topic2", and "my-topic"
+        // then also deny them read/write access to everything prefixed with "topic"
+        Crds.kafkaUserOperation(client)
+            .inNamespace(authConfig.strimziKubernetesNamespace)
+            .createOrReplace(new KafkaUserBuilder()
+                .withNewMetadata()
+                .withName(USERNAME)
+                .endMetadata()
+                .withNewSpec()
+                .withAuthentication(new KafkaUserScramSha512ClientAuthenticationBuilder().build())
+                .withAuthorization(new KafkaUserAuthorizationSimpleBuilder()
+                    .withAcls(List.of(
+                        new AclRuleBuilder()
+                            .withResource(new AclRuleTopicResourceBuilder()
+                                .withPatternType(AclResourcePatternType.LITERAL)
+                                .withName("topic1")
+                                .build())
+                            .withOperations(List.of(AclOperation.READ, AclOperation.WRITE))
+                            .withType(AclRuleType.ALLOW)
+                            .build(),
+                        new AclRuleBuilder()
+                            .withResource(new AclRuleTopicResourceBuilder()
+                                .withPatternType(AclResourcePatternType.LITERAL)
+                                .withName("topic2")
+                                .build())
+                            .withOperations(List.of(AclOperation.READ, AclOperation.WRITE))
+                            .withType(AclRuleType.ALLOW)
+                            .build(),
+                        new AclRuleBuilder()
+                            .withResource(new AclRuleTopicResourceBuilder()
+                                .withPatternType(AclResourcePatternType.PREFIX)
+                                .withName("topic")
+                                .build())
+                            .withOperations(List.of(AclOperation.ALL))
+                            .withType(AclRuleType.DENY)
+                            .build(),
+                        new AclRuleBuilder()
+                            .withResource(new AclRuleTopicResourceBuilder()
+                                .withPatternType(AclResourcePatternType.PREFIX)
+                                .withName("my-topic")
+                                .build())
+                            .withOperations(List.of(AclOperation.READ, AclOperation.WRITE))
+                            .withType(AclRuleType.ALLOW)
+                            .build()
+                    ))
+                    .build())
+                .endSpec()
+                .build());
+    }
+
+    @Test
+    void testForbidden() {
+        given()
+            .when()
+            .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+            .body(SCHEMA_BODY)
+            .with().auth().basic(USERNAME, PASSWORD)
+            .post("/ccompat/v7/subjects/{subject}/versions", "topic1-value")
+            .then()
+            .statusCode(403);
+        given()
+            .when()
+            .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+            .body(SCHEMA_BODY)
+            .with().auth().basic(USERNAME, PASSWORD)
+            .post("/ccompat/v7/subjects/{subject}/versions", "topic2-key")
+            .then()
+            .statusCode(403);
+        given()
+            .when()
+            .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+            .body(SCHEMA_BODY)
+            .with().auth().basic(USERNAME, PASSWORD)
+            .post("/ccompat/v7/subjects/{subject}/versions", "asdf")
+            .then()
+            .statusCode(403);
+    }
+
+    @Test
+    void testAuthorized() {
+        given()
+            .when()
+            .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+            .body(SCHEMA_BODY)
+            .with().auth().basic(USERNAME, PASSWORD)
+            .post("/ccompat/v7/subjects/{subject}/versions", "my-topic-value")
+            .then()
+            .statusCode(200);
+        given()
+            .when()
+            .contentType(ContentTypes.COMPAT_SCHEMA_REGISTRY_STABLE_LATEST)
+            .body(SCHEMA_BODY)
+            .with().auth().basic(USERNAME, PASSWORD)
+            .post("/ccompat/v7/subjects/{subject}/versions", "my-topic-key")
+            .then()
+            .statusCode(200);
+    }
+}

--- a/utils/tests/src/main/java/io/apicurio/registry/utils/tests/BasicAuthWithStrimziUsersTestProfile.java
+++ b/utils/tests/src/main/java/io/apicurio/registry/utils/tests/BasicAuthWithStrimziUsersTestProfile.java
@@ -13,7 +13,8 @@ public class BasicAuthWithStrimziUsersTestProfile implements QuarkusTestProfile 
         Map<String, String> map = new HashMap<>();
         map.put("quarkus.http.auth.basic", "true");
         map.put("apicurio.auth.enabled", "true");
-        map.put("apicurio.auth.owner-only-authorization", "true");
+        map.put("apicurio.auth.owner-only-authorization", "false");
+        map.put("apicurio.auth.topic-acl-based-authorizer.enabled", "true");
         map.put("apicurio.auth.basic-auth-with-strimzi-user.enabled", "true");
         return map;
     }


### PR DESCRIPTION
This controller mimics Confluent's Topic ACL-based access controller by granting permissions to read/write subjects to users that are allowed to read/write the corresponding topics